### PR TITLE
不具合修正

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -39,7 +39,7 @@ class PrototypesController < ApplicationController
   def update
     @prototype = Prototype.find(params[:id])
     if @prototype.update(prototype_params)
-      redirect_to root_path
+      redirect_to action: :show
     else
       render :edit
     end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= @user.name + "さんの情報" %>
       </h2>
       <table class="table">
         <tbody>
@@ -25,7 +25,7 @@
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= @user.name + "さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
         <%=  render partial: 'prototypes/prototype', collection: @prototypes %>


### PR DESCRIPTION
下記2点の修正
 正しく編集できた場合は、詳細ページへ遷移すること
 ログイン・ログアウトの状態に関わらず、ユーザーの詳細ページには、そのユーザーの詳細情報（名前・プロフィール・所属・役職）と、そのユーザーが投稿したプロトタイプが表示されていること
